### PR TITLE
-Fix Close #30 닉네임,비밀번호 변경 API 버그 수정

### DIFF
--- a/src/main/java/com/StreetNo5/StreetNo5/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/StreetNo5/StreetNo5/config/jwt/JwtTokenProvider.java
@@ -41,6 +41,9 @@ public class JwtTokenProvider {
     public UserResponseDto.TokenInfo generateToken(Authentication authentication) {
         return generateToken(authentication.getName(), authentication.getAuthorities());
     }
+    public UserResponseDto.TokenInfo generateToken(Authentication authentication,String newNickname) {
+        return generateToken(newNickname, authentication.getAuthorities());
+    }
     public UserResponseDto.TokenInfo generateAccessToken(String name,
                                                    Collection<? extends GrantedAuthority> inputAuthorities) {
         //권한 가져오기

--- a/src/main/java/com/StreetNo5/StreetNo5/domain/User.java
+++ b/src/main/java/com/StreetNo5/StreetNo5/domain/User.java
@@ -61,13 +61,11 @@ public class User extends BaseTimeEntity{
         this.role = role;
     }
 
-    public User nicknameUpdate(String nickname) {
+    public void nicknameUpdate(String nickname) {
         this.nickname = nickname;
-        return this;
     }
-    public User passwordUpdate(String newPassword) {
+    public void passwordUpdate(String newPassword) {
         this.password = newPassword;
-        return this;
     }
 
     public String getRoleKey() {

--- a/src/main/java/com/StreetNo5/StreetNo5/repository/UserRepository.java
+++ b/src/main/java/com/StreetNo5/StreetNo5/repository/UserRepository.java
@@ -8,4 +8,9 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNickname(String nickname);
     boolean existsUsersByNickname(String nickname);
+
+/*    @Transactional
+    @Modifying
+    @Query(value = "update user p set p.password =:newPassword where p.nickname=:nickname",nativeQuery = true)
+    void updatePassword(@Param("nickname") String nickname,@Param("password")String newPassword);*/
 }


### PR DESCRIPTION
변경 사항

이전 기능
닉네임 변경 이후 토큰을 재 발급 했어야 했는데 발급 안하고, 유저 검증도 안했음

현재 기능
닉네임 변경 이전 토큰 logout 처리(redis에서 변수 추가해서 blacklist 추가하는형식), 유저 검증 이후 access ,refresh 토큰 재발급