### PR TITLE
-Fix Close #79 인기 게시물 조회 N+1 문제 해결 (쿼리 수정)

### DIFF
--- a/src/main/java/com/StreetNo5/StreetNo5/repository/BoardRepository.java
+++ b/src/main/java/com/StreetNo5/StreetNo5/repository/BoardRepository.java
@@ -15,7 +15,7 @@ public interface BoardRepository extends JpaRepository<UserPost,Long> {
     @Query(value = "update user_post p set p.view_count = p.view_count + 1 where p.post_id=:id",nativeQuery = true)
     void updatePageView(@Param("id") Long id);
 
-    @Query(value = "select * from user_post order by view_count desc limit 5",nativeQuery = true)
+    @Query(value = "select u from UserPost u left join fetch u.user order by u.viewCount desc limit 5")
     List<UserPost> findPolarPost();
 
     @Query(value = "select u from UserPost u left join fetch u.user" )


### PR DESCRIPTION
변경 사항

이전 기능
인기 게시물 조회시 N+1 발생

현재 기능
인기 게시물 조회시 fetch join 으로 N+1 해결
참고 사항

이전 쿼리
@query(value = "select * from user_post order by view_count desc limit 5",nativeQuery = true)
List findPolarPost();
현재 쿼리
@query(value = "select u from UserPost u left join fetch u.user order by u.viewCount desc limit 5")
List findPolarPost();